### PR TITLE
Add GitHub Actions workflow for native builds

### DIFF
--- a/.github/workflows/native-build.yml
+++ b/.github/workflows/native-build.yml
@@ -31,6 +31,10 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           components: native-image
 
+      - name: Ensure mvnw is executable
+        run: chmod +x mvnw
+        shell: bash
+
       - name: Build native image
         run: ./mvnw -DskipTests native:compile
         shell: bash

--- a/.github/workflows/native-build.yml
+++ b/.github/workflows/native-build.yml
@@ -1,0 +1,65 @@
+name: Native Build
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  native-image:
+    name: Native build (${{ matrix.os }})
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest
+          - windows-latest
+    runs-on: ${{ matrix.os }}
+    env:
+      APP_NAME: yapi-mcp-server
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup GraalVM
+        uses: graalvm/setup-graalvm@v1
+        with:
+          java-version: '21'
+          distribution: 'graalvm'
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          components: native-image
+
+      - name: Build native image
+        run: ./mvnw -DskipTests native:compile
+        shell: bash
+
+      - name: Collect native executable
+        id: collect
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p native-artifacts
+          for candidate in \
+            "target/${APP_NAME}" \
+            "target/${APP_NAME}.exe" \
+            "target/native/nativeCompile/${APP_NAME}" \
+            "target/native/nativeCompile/${APP_NAME}.exe"; do
+            if [ -f "$candidate" ]; then
+              cp "$candidate" native-artifacts/
+            fi
+          done
+
+          if [ "$(ls -A native-artifacts)" = "" ]; then
+            echo "未找到原生可执行文件" >&2
+            find target -maxdepth 3 -type f -print || true
+            exit 1
+          fi
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: native-${{ matrix.os }}
+          path: native-artifacts/
+          if-no-files-found: error

--- a/README.md
+++ b/README.md
@@ -59,6 +59,10 @@ vim src/main/resources/application-mcp.yml
 docker-compose up -d
 ```
 
+## Native Executables
+
+This repository provides a **Native Build** GitHub Actions workflow that compiles platform-specific binaries with GraalVM native-image for Linux, macOS, and Windows. After the workflow finishes, you can download the executable that matches your system from the workflow run page under **Artifacts** (for Windows the file ends with `.exe`).
+
 ## Configuration
 
 Before running the application, you need to configure your Yapi connection settings in `src/main/resources/application-mcp.yml`:

--- a/README_zh.md
+++ b/README_zh.md
@@ -57,6 +57,10 @@ vim src/main/resources/application-mcp.yml
 docker-compose up -d
 ```
 
+## 原生可执行文件
+
+仓库内提供了 **Native Build** GitHub Actions 工作流，使用 GraalVM 的 native-image 功能为 Linux、macOS 和 Windows 编译对应的原生可执行文件。工作流完成后，可在对应运行页面的 **Artifacts** 区域下载适合当前系统的二进制文件（Windows 平台的文件扩展名为 `.exe`）。
+
 ## 配置说明
 
 在运行应用程序之前，您需要在 `src/main/resources/application-mcp.yml` 中配置 Yapi 连接设置：


### PR DESCRIPTION
## Summary
- add a matrix GitHub Actions workflow that installs GraalVM and builds native images on Ubuntu, macOS, and Windows
- collect the generated executables and publish them as workflow artifacts
- document where to download the native binaries in both English and Chinese READMEs

## Testing
- not run (workflow configuration only)


------
https://chatgpt.com/codex/tasks/task_b_6904515962cc832593246b49c143d999