### PR TITLE
:memo: docs: 推荐使用 Yapi Skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Yapi MCP Server
 
+> **Recommended:** If you only need to search Yapi interfaces or get interface details, use the lightweight [Yapi Skill](https://github.com/yyykf/spellbook-skills/blob/main/skills/yapi-skill/SKILL.md) first. It calls Yapi through local Python scripts and does not require starting the Java/Docker MCP server. Use this project when you need a full MCP server integration.
+
 A Model Context Protocol (MCP) Server for Yapi API management platform. This project provides seamless integration between AI assistants and Yapi, allowing you to query API documentation, search interfaces, and manage API information through natural language.
 
 For the Chinese version of this document, please see [README_zh.md](./README_zh.md).

--- a/README_zh.md
+++ b/README_zh.md
@@ -1,5 +1,7 @@
 # Yapi MCP 服务器
 
+> **推荐方式：** 如果你只是需要搜索 Yapi 接口或获取接口详情，优先使用轻量的 [Yapi Skill](https://github.com/yyykf/spellbook-skills/blob/main/skills/yapi-skill/SKILL.md)。它通过本地 Python 脚本直接调用 Yapi，不需要启动 Java/Docker MCP Server。只有在需要完整 MCP Server 集成时，再使用本项目。
+
 一个用于 Yapi API 管理平台的模型上下文协议（MCP）服务器。本项目提供了 AI 助手与 Yapi 之间的无缝集成，让您可以通过自然语言查询 API 文档、搜索接口并管理 API 信息。
 
 ## 功能特性


### PR DESCRIPTION
## 变更概述

在中英文 README 顶部增加推荐说明：如果只是搜索 Yapi 接口或获取接口详情，优先使用 spellbook-skills 的 Yapi Skill；只有需要完整 MCP Server 集成时再使用本项目。

## 主要改动

- README.md 增加英文推荐备注和 Skill 链接
- README_zh.md 增加中文推荐备注和 Skill 链接

[#AI]